### PR TITLE
Show standard output and error even if ffmpeg command fails

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -49,9 +49,9 @@ func convertAACToMP3(inputFilePath, outputFilePath string) error {
 		"-q:a", "2",
 	)
 	result, err := f.execute(outputFilePath)
+	log.Println(string(result))
 	if err != nil {
 		return err
 	}
-	log.Println(string(result))
 	return nil
 }


### PR DESCRIPTION
I encountered an error while running ffmpeg command (e.g. `too many open files`) but the standard error was not shown which made it difficult to resolve the error.

This PR fixes this. Any thoughts? Thank you!

### Before this PR
```shell
% ffmpego -i http://example.com/sample.m3u8
2016/12/18 13:27:15 exit status 1
```

### After this PR
```shell
% ffmpego -i http://example.com/sample.m3u8
ffmpeg version 3.2.2 Copyright (c) 2000-2016 the FFmpeg developers                                                                                                         [260/1199]
  built with Apple LLVM version 8.0.0 (clang-800.0.42.1)
  configuration: --prefix=/usr/local/Cellar/ffmpeg/3.2.2 --enable-shared --enable-pthreads --enable-gpl --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --
host-cflags= --host-ldflags= --enable-libmp3lame --enable-libx264 --enable-libxvid --enable-opencl --disable-lzma --enable-vda
  libavutil      55. 34.100 / 55. 34.100
  libavcodec     57. 64.101 / 57. 64.101
  libavformat    57. 56.100 / 57. 56.100
  libavdevice    57.  1.100 / 57.  1.100
  libavfilter     6. 65.100 /  6. 65.100
  libavresample   3.  1.  0 /  3.  1.  0
  libswscale      4.  2.100 /  4.  2.100
  libswresample   2.  3.100 /  2.  3.100
  libpostproc    54.  1.100 / 54.  1.100
concat:tmp/8607-1.ts|tmp/8607-2.ts|tmp/8607-3.ts|tmp/8607-4.ts|tmp/8607-5.ts|tmp/8607-6.ts|tmp/8607-7.ts|tmp/8607-8.ts|tmp/8607-9.ts|tmp/8607-10.ts|tmp/8607-11.ts|tmp/8607-12.ts|tmp
/8607-13.ts|tmp/8607-14.ts|tmp/8607-15.ts|tmp/8607-16.ts|tmp/8607-17.ts|tmp/8607-18.ts|tmp/8607-19.ts|tmp/8607-20.ts|tmp/8607-21.ts|tmp/8607-22.ts|tmp/8607-23.ts|tmp/8607-24.ts|tmp/
8607-25.ts|tmp/8607-26.ts|tmp/8607-27.ts|tmp/8607-28.ts|tmp/8607-29.ts|tmp/8607-30.ts|tmp/8607-31.ts|tmp/8607-32.ts|tmp/8607-33.ts|tmp/8607-34.ts|tmp/8607-35.ts|tmp/8607-36.ts|tmp/8
607-37.ts|tmp/8607-38.ts|tmp/8607-39.ts|tmp/8607-40.ts|tmp/8607-41.ts|tmp/8607-42.ts|tmp/8607-43.ts|tmp/8607-44.ts|tmp/8607-45.ts|tmp/8607-46.ts|tmp/8607-47.ts|tmp/8607-48.ts|tmp/86
07-49.ts|tmp/8607-50.ts|tmp/8607-51.ts|tmp/8607-52.ts|tmp/8607-53.ts|tmp/8607-54.ts|tmp/8607-55.ts|tmp/8607-56.ts|tmp/8607-57.ts|tmp/8607-58.ts|tmp/8607-59.ts|tmp/8607-60.ts|tmp/860
7-61.ts|tmp/8607-62.ts|tmp/8607-63.ts|tmp/8607-64.ts|tmp/8607-65.ts|tmp/8607-66.ts|tmp/8607-67.ts|tmp/8607-68.ts|tmp/8607-69.ts|tmp/8607-70.ts|tmp/8607-71.ts|tmp/8607-72.ts|tmp/8607
-73.ts|tmp/8607-74.ts|tmp/8607-75.ts|tmp/8607-76.ts|tmp/8607-77.ts|tmp/8607-78.ts|tmp/8607-79.ts|tmp/8607-80.ts|tmp/8607-81.ts|tmp/8607-82.ts|tmp/8607-83.ts|tmp/8607-84.ts|tmp/8607-
85.ts|tmp/8607-86.ts|tmp/8607-87.ts|tmp/8607-88.ts|tmp/8607-89.ts|tmp/8607-90.ts|tmp/8607-91.ts|tmp/8607-92.ts|tmp/8607-93.ts|tmp/8607-94.ts|tmp/8607-95.ts|tmp/8607-96.ts|tmp/8607-9
7.ts|tmp/8607-98.ts|tmp/8607-99.ts|tmp/8607-100.ts|tmp/8607-101.ts|tmp/8607-102.ts|tmp/8607-103.ts|tmp/8607-104.ts|tmp/8607-105.ts|tmp/8607-106.ts|tmp/8607-107.ts|tmp/8607-108.ts|tm
p/8607-109.ts|tmp/8607-110.ts|tmp/8607-111.ts|tmp/8607-112.ts|tmp/8607-113.ts|tmp/8607-114.ts|tmp/8607-115.ts|tmp/8607-116.ts|tmp/8607-117.ts|tmp/8607-118.ts|tmp/8607-119.ts|tmp/860
7-120.ts|tmp/8607-121.ts|tmp/8607-122.ts|tmp/8607-123.ts|tmp/8607-124.ts|tmp/8607-125.ts|tmp/8607-126.ts|tmp/8607-127.ts|tmp/8607-128.ts|tmp/8607-129.ts|tmp/8607-130.ts|tmp/8607-131
.ts|tmp/8607-132.ts|tmp/8607-133.ts|tmp/8607-134.ts|tmp/8607-135.ts|tmp/8607-136.ts|tmp/8607-137.ts|tmp/8607-138.ts|tmp/8607-139.ts|tmp/8607-140.ts|tmp/8607-141.ts|tmp/8607-142.ts|t
mp/8607-143.ts|tmp/8607-144.ts|tmp/8607-145.ts|tmp/8607-146.ts|tmp/8607-147.ts|tmp/8607-148.ts|tmp/8607-149.ts|tmp/8607-150.ts|tmp/8607-151.ts|tmp/8607-152.ts|tmp/8607-153.ts|tmp/86
07-154.ts|tmp/8607-155.ts|tmp/8607-156.ts|tmp/8607-157.ts|tmp/8607-158.ts|tmp/8607-159.ts|tmp/8607-160.ts|tmp/8607-161.ts|tmp/8607-162.ts|tmp/8607-163.ts|tmp/8607-164.ts|tmp/8607-16
5.ts|tmp/8607-166.ts|tmp/8607-167.ts|tmp/8607-168.ts|tmp/8607-169.ts|tmp/8607-170.ts|tmp/8607-171.ts|tmp/8607-172.ts|tmp/8607-173.ts|tmp/8607-174.ts|tmp/8607-175.ts|tmp/8607-176.ts|
tmp/8607-177.ts|tmp/8607-178.ts|tmp/8607-179.ts|tmp/8607-180.ts|tmp/8607-181.ts|tmp/8607-182.ts|tmp/8607-183.ts|tmp/8607-184.ts|tmp/8607-185.ts|tmp/8607-186.ts|tmp/8607-187.ts|tmp/8
607-188.ts|tmp/8607-189.ts|tmp/8607-190.ts|tmp/8607-191.ts|tmp/8607-192.ts|tmp/8607-193.ts|tmp/8607-194.ts|tmp/8607-195.ts|tmp/8607-196.ts|tmp/8607-197.ts|tmp/8607-198.ts|tmp/8607-1
99.ts|tmp/8607-200.ts|tmp/8607-201.ts|tmp/8607-202.ts|tmp/8607-203.ts|tmp/8607-204.ts|tmp/8607-205.ts|tmp/8607-206.ts|tmp/8607-207.ts|tmp/8607-208.ts|tmp/8607-209.ts|tmp/8607-210.ts
|tmp/8607-211.ts|tmp/8607-212.ts|tmp/8607-213.ts|tmp/8607-214.ts|tmp/8607-215.ts|tmp/8607-216.ts|tmp/8607-217.ts|tmp/8607-218.ts|tmp/8607-219.ts|tmp/8607-220.ts|tmp/8607-221.ts|tmp/
8607-222.ts|tmp/8607-223.ts|tmp/8607-224.ts|tmp/8607-225.ts|tmp/8607-226.ts|tmp/8607-227.ts|tmp/8607-228.ts|tmp/8607-229.ts|tmp/8607-230.ts|tmp/8607-231.ts|tmp/8607-232.ts|tmp/8607-
233.ts|tmp/8607-234.ts|tmp/8607-235.ts|tmp/8607-236.ts|tmp/8607-237.ts|tmp/8607-238.ts|tmp/8607-239.ts|tmp/8607-240.ts|tmp/8607-241.ts|tmp/8607-242.ts|tmp/8607-243.ts|tmp/8607-244.t
s|tmp/8607-245.ts|tmp/8607-246.ts|tmp/8607-247.ts|tmp/8607-248.ts|tmp/8607-249.ts|tmp/8607-250.ts|tmp/8607-251.ts|tmp/8607-252.ts|tmp/8607-253.ts|tmp/8607-254.ts|tmp/8607-255.ts|tmp
/8607-256.ts|tmp/8607-257.ts|tmp/8607-258.ts|tmp/8607-259.ts|tmp/8607-260.ts|tmp/8607-261.ts|tmp/8607-262.ts|tmp/8607-263.ts|tmp/8607-264.ts|tmp/8607-265.ts|tmp/8607-266.ts|tmp/8607
-267.ts|tmp/8607-268.ts|tmp/8607-269.ts|tmp/8607-270.ts|tmp/8607-271.ts|tmp/8607-272.ts|tmp/8607-273.ts|tmp/8607-274.ts|tmp/8607-275.ts|tmp/8607-276.ts|tmp/8607-277.ts|tmp/8607-278.
ts|tmp/8607-279.ts|tmp/8607-280.ts|tmp/8607-281.ts|tmp/8607-282.ts|tmp/8607-283.ts|tmp/8607-284.ts|tmp/8607-285.ts|tmp/8607-286.ts|tmp/8607-287.ts|tmp/8607-288.ts|tmp/8607-289.ts|tm
p/8607-290.ts|tmp/8607-291.ts|tmp/8607-292.ts|tmp/8607-293.ts|tmp/8607-294.ts|tmp/8607-295.ts|tmp/8607-296.ts|tmp/8607-297.ts|tmp/8607-298.ts|tmp/8607-299.ts|tmp/8607-300.ts|tmp/860
7-301.ts|tmp/8607-302.ts|tmp/8607-303.ts|tmp/8607-304.ts|tmp/8607-305.ts|tmp/8607-306.ts|tmp/8607-307.ts|tmp/8607-308.ts|tmp/8607-309.ts|tmp/8607-310.ts|tmp/8607-311.ts|tmp/8607-312
.ts|tmp/8607-313.ts|tmp/8607-314.ts|tmp/8607-315.ts|tmp/8607-316.ts|tmp/8607-317.ts|tmp/8607-318.ts|tmp/8607-319.ts|tmp/8607-320.ts|tmp/8607-321.ts|tmp/8607-322.ts|tmp/8607-323.ts|t
mp/8607-324.ts|tmp/8607-325.ts|tmp/8607-326.ts|tmp/8607-327.ts|tmp/8607-328.ts|tmp/8607-329.ts|tmp/8607-330.ts|tmp/8607-331.ts|tmp/8607-332.ts|tmp/8607-333.ts|tmp/8607-334.ts|tmp/86
07-335.ts|tmp/8607-336.ts|tmp/8607-337.ts|tmp/8607-338.ts|tmp/8607-339.ts|tmp/8607-340.ts|tmp/8607-341.ts|tmp/8607-342.ts|tmp/8607-343.ts|tmp/8607-344.ts|tmp/8607-345.ts|tmp/8607-34
6.ts|tmp/8607-347.ts|tmp/8607-348.ts|tmp/8607-349.ts|tmp/8607-350.ts|tmp/8607-351.ts|tmp/8607-352.ts|tmp/8607-353.ts|tmp/8607-354.ts|tmp/8607-355.ts|tmp/8607-356.ts|tmp/8607-357.ts|
tmp/8607-358.ts|tmp/8607-359.ts|tmp/8607-360.ts|tmp/8607-361.ts|tmp/8607-362.ts|tmp/8607-363.ts|tmp/8607-364.ts|tmp/8607-365.ts|tmp/8607-366.ts|tmp/8607-367.ts|tmp/8607-368.ts|tmp/8
607-369.ts|tmp/8607-370.ts|tmp/8607-371.ts|tmp/8607-372.ts|tmp/8607-373.ts|tmp/8607-374.ts|tmp/8607-375.ts|tmp/8607-376.ts|tmp/8607-377.ts|tmp/8607-378.ts|tmp/8607-379.ts|tmp/8607-3
80.ts|tmp/8607-381.ts|tmp/8607-382.ts|tmp/8607-383.ts|tmp/8607-384.ts|tmp/8607-385.ts|tmp/8607-386.ts|tmp/8607-387.ts|tmp/8607-388.ts|tmp/8607-389.ts|tmp/8607-390.ts|tmp/8607-391.ts
|tmp/8607-392.ts|tmp/8607-393.ts|tmp/8607-394.ts|tmp/8607-395.ts|tmp/8607-396.ts|tmp/8607-397.ts|tmp/8607-398.ts|tmp/8607-399.ts|tmp/8607-400.ts|tmp/8607-401.ts|tmp/8607-402.ts|tmp/
8607-403.ts|tmp/8607-404.ts|tmp/8607-405.ts|tmp/8607-406.ts|tmp/8607-407.ts|tmp/8607-408.ts|tmp/8607-409.ts|tmp/8607-410.ts|tmp/8607-411.ts|tmp/8607-412.ts|tmp/8607-413.ts|tmp/8607-
414.ts|tmp/8607-415.ts|tmp/8607-416.ts|tmp/8607-417.ts|tmp/8607-418.ts|tmp/8607-419.ts|tmp/8607-420.ts: Too many open files
```